### PR TITLE
Don't consider user names when deciding on dataclass equality

### DIFF
--- a/squash_bot/core/data/dataclasses.py
+++ b/squash_bot/core/data/dataclasses.py
@@ -4,8 +4,8 @@ import attrs
 @attrs.frozen
 class User:
     id: str
-    username: str
-    global_name: str
+    username: str = attrs.field(eq=False)
+    global_name: str = attrs.field(eq=False)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Prior to this change, we would consider a `User` to be the same if all attributes of the dataclass were equal. We want to support users with names changes so we should only use the `id` when deciding if a user is the same as another.