### PR TITLE
Handle error in `command.handle`

### DIFF
--- a/squash_bot/core/lambda_function.py
+++ b/squash_bot/core/lambda_function.py
@@ -3,6 +3,7 @@ import json
 import logging
 import typing
 
+from squash_bot.core import command as _command
 from squash_bot.core import command_registry, response, verify
 from squash_bot.settings import base as settings_base
 
@@ -77,7 +78,17 @@ def command_handler(body: dict[str, typing.Any]) -> response.Response:
             body_data="Unknown command",
         )
     logger.info(f"Handling command {command_name}")
-    command_response_data = command.handle(body)
+    try:
+        command_response_data = command.handle(body)
+    except _command.CommandVerificationError as e:
+        return response.Response(
+            status_code=500,
+            body_data=str(e),
+        )
+    except _command.CommandError as e:
+        logger.error(f"Error handling command {command_name}: {e}")
+        raise e
+
     return response.Response(
         status_code=200,
         body_data=command_response_data,


### PR DESCRIPTION
Prior to this change, all errors that occured during the execution of a command's `handle` method were simply left unhandled.

This change generally keeps that behaviour (with an added call to logger) however does handle some special handling for the `CommandVerificationError` which is a subset of the overall `CommandError` used to indicate a user error. For these kinds of errors we return a 500 to the user with the error message to help the user understand their mistake.