### PR TITLE
Add generic filter / order / format mixin to allow for easier command writing

### DIFF
--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -130,7 +130,7 @@ class LeagueTableCommand(_command.Command):
     options = (
         _command.CommandOption(
             name="include-matches-from",
-            description="Only include matches played after this date. Defaults to all time.",
+            description="Only include matches played on or after this date. Defaults to all time.",
             type=_command.CommandOptionType.STRING,
             required=False,
         ),

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -154,7 +154,7 @@ class ShowMatchesCommand(_command.Command):
 
 
 @command_registry.registry.register
-class LeagueTableCommand(_command.Command):
+class LeagueTableCommand(FilterOrderFormatMatchesMixin, _command.Command):
     name = "league-table"
     description = "Show league table."
     options = (
@@ -166,27 +166,5 @@ class LeagueTableCommand(_command.Command):
         ),
     )
 
-    def _handle(
-        self,
-        options: dict[str, typing.Any],
-        base_context: dict[str, typing.Any],
-        guild: core_dataclasses.Guild,
-        user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
-        matches = queries.get_matches(guild)
-
-        if from_date_string := options.get("include-matches-from"):
-            from_date = datetime.date.fromisoformat(from_date_string)
-            matches = matches.from_date(from_date)
-
-        if matches:
-            content = formatters.LeagueTable.format_matches(matches)
-        else:
-            content = "No matches have been recorded."
-
-        return {
-            "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-            "data": {
-                "content": content,
-            },
-        }
+    filterer = filterers.OptionalFromDateFilterer
+    formatter = formatters.LeagueTable

--- a/squash_bot/match_tracker/filterers.py
+++ b/squash_bot/match_tracker/filterers.py
@@ -1,0 +1,9 @@
+import abc
+
+from squash_bot.match_tracker.data import dataclasses
+
+
+class Filterer(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def filter(self, matches: dataclasses.Matches) -> dataclasses.Matches: ...

--- a/squash_bot/match_tracker/filterers.py
+++ b/squash_bot/match_tracker/filterers.py
@@ -6,4 +6,10 @@ from squash_bot.match_tracker.data import dataclasses
 class Filterer(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def filter(self, matches: dataclasses.Matches) -> dataclasses.Matches: ...
+    def filter(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches: ...
+
+
+class NoopFilterer(Filterer):
+    @classmethod
+    def filter(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
+        return matches

--- a/squash_bot/match_tracker/filterers.py
+++ b/squash_bot/match_tracker/filterers.py
@@ -1,4 +1,5 @@
 import abc
+import datetime
 
 from squash_bot.match_tracker.data import dataclasses
 
@@ -12,4 +13,13 @@ class Filterer(abc.ABC):
 class NoopFilterer(Filterer):
     @classmethod
     def filter(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
+        return matches
+
+
+class OptionalFromDateFilterer(Filterer):
+    @classmethod
+    def filter(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
+        if from_date_string := kwargs.get("include-matches-from"):
+            from_date = datetime.date.fromisoformat(from_date_string)
+            matches = matches.from_date(from_date)
         return matches

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -10,23 +10,19 @@ from squash_bot.match_tracker.data import dataclasses
 class Formatter(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def format_matches(cls, matches: dataclasses.Matches) -> str: ...
+    def format_matches(cls, matches: dataclasses.Matches, **kwargs) -> str: ...
 
 
 class BasicFormatter(Formatter):
     @classmethod
-    def format_matches(cls, matches: dataclasses.Matches) -> str:
-        inner_message = ""
-        for match in matches.match_results:
-            match_string = _match_string(match)
-            inner_message += f"\n{match_string}"
-
+    def format_matches(cls, matches: dataclasses.Matches, **kwargs) -> str:
+        inner_message = "\n".join(_match_string(match) for match in matches.match_results)
         return f"```{inner_message}```"
 
 
 class PlayedAtFormatter(Formatter):
     @classmethod
-    def format_matches(cls, matches: dataclasses.Matches) -> str:
+    def format_matches(cls, matches: dataclasses.Matches, **kwargs) -> str:
         groups = itertools.groupby(matches.match_results, key=lambda match: match.played_on)
 
         inner_message = ""
@@ -42,7 +38,7 @@ class PlayedAtFormatter(Formatter):
 
 class LeagueTable(Formatter):
     @classmethod
-    def format_matches(cls, matches: dataclasses.Matches) -> str:
+    def format_matches(cls, matches: dataclasses.Matches, **kwargs) -> str:
         player_results = collections.defaultdict(dict)
         for match in matches.match_results:
             player_results[match.winner]["wins"] = player_results[match.winner].get("wins", 0) + 1

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -39,27 +39,15 @@ class LeagueTable(Formatter):
                 player_results[match.loser].get("losses", 0) + 1
             )
 
-            point_difference = match.winner_score - match.loser_score
-            player_results[match.winner]["point_difference"] = (
-                player_results[match.winner].get("point_difference", 0) + point_difference
-            )
-            player_results[match.loser]["point_difference"] = (
-                player_results[match.loser].get("point_difference", 0) - point_difference
-            )
-
         player_rows = []
         for player, results in player_results.items():
             wins = results.get("wins", 0)
             losses = results.get("losses", 0)
 
-            point_difference = results.get("point_difference", 0)
-            point_difference_sign = "+" if point_difference > 0 else ""
-            point_difference_str = f"{point_difference_sign}{point_difference}"
-
-            player_rows.append([player.name, wins, losses, point_difference_str])
+            player_rows.append([player.name, wins, losses])
 
         inner_message = tabulate.tabulate(
-            player_rows, ["Player", "Wins", "Losses", "PD"], tablefmt="rounded_grid"
+            player_rows, ["Player", "Wins", "Losses"], tablefmt="rounded_grid"
         )
 
         return f"```{inner_message}```"

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -13,6 +13,17 @@ class Formatter(abc.ABC):
     def format_matches(cls, matches: dataclasses.Matches) -> str: ...
 
 
+class BasicFormatter(Formatter):
+    @classmethod
+    def format_matches(cls, matches: dataclasses.Matches) -> str:
+        inner_message = ""
+        for match in matches.match_results:
+            match_string = _match_string(match)
+            inner_message += f"\n{match_string}"
+
+        return f"```{inner_message}```"
+
+
 class PlayedAtFormatter(Formatter):
     @classmethod
     def format_matches(cls, matches: dataclasses.Matches) -> str:

--- a/squash_bot/match_tracker/orderers.py
+++ b/squash_bot/match_tracker/orderers.py
@@ -1,0 +1,9 @@
+import abc
+
+from squash_bot.match_tracker.data import dataclasses
+
+
+class Orderer(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def order(self, matches: dataclasses.Matches) -> dataclasses.Matches: ...

--- a/squash_bot/match_tracker/orderers.py
+++ b/squash_bot/match_tracker/orderers.py
@@ -6,4 +6,10 @@ from squash_bot.match_tracker.data import dataclasses
 class Orderer(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def order(self, matches: dataclasses.Matches) -> dataclasses.Matches: ...
+    def order(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches: ...
+
+
+class NoopOrderer(Orderer):
+    @classmethod
+    def order(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
+        return matches

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -257,8 +257,8 @@ class TestLeagueTable:
             )
 
         content = response["data"]["content"]
-        assert "global-user1 │      1 │        1 │   +4" in content
-        assert "global-user2 │      1 │        1 │   -4" in content
+        assert "global-user1 │      1 │        1" in content
+        assert "global-user2 │      1 │  " in content
 
     def test_league_table_with_datetime_filter(self):
         user_one = core_dataclasses.User(id="1", username="user1", global_name="global-user1")
@@ -300,5 +300,5 @@ class TestLeagueTable:
             )
 
         content = response["data"]["content"]
-        assert "global-user2 │      1 │        0 │   +2" in content
-        assert "global-user1 │      0 │        1 │   -2" in content
+        assert "global-user2 │      1 │        0" in content
+        assert "global-user1 │      0 │        1" in content


### PR DESCRIPTION
Some of the commands we want to add are all flavours of a very similar concept. Get some matches, change the order of them and then format those matches to a string.

Instead of each command having to write it's own plumbing to do that, we can add a generic mixin that handles all that for us.