### PR TITLE
Add response message classes to simplify return values in command._handle methods

### DIFF
--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -1,6 +1,5 @@
-import typing
-
 import attrs
+import typing
 
 from squash_bot.core import response_message
 from squash_bot.core.data import constants as core_constants

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -2,6 +2,7 @@ import typing
 
 import attrs
 
+from squash_bot.core import response_message
 from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 
@@ -103,7 +104,7 @@ class Command:
             global_name=user_data["global_name"],
         )
 
-    def handle(self, base_context: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    def handle(self, base_context: dict[str, typing.Any]) -> response_message.ResponseBody:
         command_options = self.parse_options(base_context)
         guild = self.parse_guild(base_context)
         user = self.parse_user(base_context)
@@ -117,7 +118,7 @@ class Command:
         base_context: dict[str, typing.Any],
         guild: core_dataclasses.Guild,
         user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
+    ) -> response_message.ResponseBody:
         """
         Should be implemented by subclasses to handle the command.
 

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -1,5 +1,6 @@
-import attrs
 import typing
+
+import attrs
 
 from squash_bot.core import response_message
 from squash_bot.core.data import constants as core_constants

--- a/squash_bot/core/lambda_function.py
+++ b/squash_bot/core/lambda_function.py
@@ -4,7 +4,7 @@ import logging
 import typing
 
 from squash_bot.core import command as _command
-from squash_bot.core import command_registry, response, verify
+from squash_bot.core import command_registry, response, response_message, verify
 from squash_bot.settings import base as settings_base
 
 logger = logging.getLogger()
@@ -19,11 +19,6 @@ class InteractionTypeEnum(enum.Enum):
     @classmethod
     def _missing_(cls, value) -> "InteractionTypeEnum":
         return cls.UNKNOWN
-
-
-class InteractionResponseType(enum.Enum):
-    PONG = 1
-    CHANNEL_MESSAGE_WITH_SOURCE = 4
 
 
 def lambda_handler(
@@ -63,7 +58,7 @@ def ping_handler(body: dict[str, typing.Any]) -> response.Response:
     logger.info("Handling ping")
     return response.Response(
         status_code=200,
-        body_data={"type": InteractionResponseType.PONG.value},
+        body_data={"type": response_message.InteractionResponseType.PONG.value},
     )
 
 
@@ -79,7 +74,7 @@ def command_handler(body: dict[str, typing.Any]) -> response.Response:
         )
     logger.info(f"Handling command {command_name}")
     try:
-        command_response_data = command.handle(body)
+        command_response_data = command.handle(body).as_dict()
     except _command.CommandVerificationError as e:
         return response.Response(
             status_code=500,

--- a/squash_bot/core/response_message.py
+++ b/squash_bot/core/response_message.py
@@ -1,6 +1,7 @@
-import attrs
 import enum
 import typing
+
+import attrs
 
 
 class InteractionResponseType(enum.Enum):

--- a/squash_bot/core/response_message.py
+++ b/squash_bot/core/response_message.py
@@ -1,0 +1,49 @@
+import enum
+import typing
+
+
+class InteractionResponseType(enum.Enum):
+    PONG = 1
+    CHANNEL_MESSAGE_WITH_SOURCE = 4
+    PREMIUM_REQUIRED = 10
+
+
+class ResponseFlags(enum.Enum):
+    """
+    Bitwise flag operations - see https://discord.com/developers/docs/resources/channel#message-object-message-flags
+    """
+
+    EPHEMERAL = 1 << 6
+    LOADING = 1 << 7
+
+
+class ResponseBody:
+    def __init__(self, response_type: InteractionResponseType, content: str):
+        self._response_type = response_type
+        self.content = content
+
+    def as_dict(self) -> dict[str, typing.Any]:
+        return {"type": self._response_type.value, "data": {"content": self.content}}
+
+
+class ChannelMessageResponseBody(ResponseBody):
+    """
+    A message response to the channel where the command was called
+    """
+
+    def __init__(self, content):
+        super().__init__(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE, content)
+
+
+class EphemeralChannelMessageResponseBody(ChannelMessageResponseBody):
+    """
+    A message response to only the user that called the command in the channel where the command was called
+    """
+
+    def __init__(self, content):
+        super().__init__(content)
+
+    def as_dict(self) -> dict[str, typing.Any]:
+        base_dict = super().as_dict()
+        base_dict["data"]["flags"] = ResponseFlags.EPHEMERAL.value
+        return base_dict

--- a/squash_bot/core/response_message.py
+++ b/squash_bot/core/response_message.py
@@ -1,3 +1,4 @@
+import attrs
 import enum
 import typing
 
@@ -17,31 +18,29 @@ class ResponseFlags(enum.Enum):
     LOADING = 1 << 7
 
 
+@attrs.frozen(kw_only=True)
 class ResponseBody:
-    def __init__(self, response_type: InteractionResponseType, content: str):
-        self._response_type = response_type
-        self.content = content
+    _response_type: InteractionResponseType
+    content: str
 
     def as_dict(self) -> dict[str, typing.Any]:
         return {"type": self._response_type.value, "data": {"content": self.content}}
 
 
+@attrs.frozen(kw_only=True)
 class ChannelMessageResponseBody(ResponseBody):
     """
     A message response to the channel where the command was called
     """
 
-    def __init__(self, content):
-        super().__init__(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE, content)
+    _response_type: InteractionResponseType = InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE
 
 
+@attrs.frozen(kw_only=True)
 class EphemeralChannelMessageResponseBody(ChannelMessageResponseBody):
     """
     A message response to only the user that called the command in the channel where the command was called
     """
-
-    def __init__(self, content):
-        super().__init__(content)
 
     def as_dict(self) -> dict[str, typing.Any]:
         base_dict = super().as_dict()

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -92,7 +92,7 @@ class ListTimetableCommand(_command.Command):
             else:
                 message += f" between {from_date_str} and {to_date_str}"
 
-            return response_message.ChannelMessageResponseBody(message)
+            return response_message.ChannelMessageResponseBody(content=message)
 
         # Store the time period (default is 'from_date' if only 1 day requested) for the response message header
         time_period_str = from_date_str
@@ -100,7 +100,7 @@ class ListTimetableCommand(_command.Command):
             time_period_str += f" - {to_date_str}"
 
         return response_message.ChannelMessageResponseBody(
-            self._get_response_message(
+            content=self._get_response_message(
                 filtered_timetable_sessions, f"{time_of_day.value} slots ({time_period_str})"
             )
         )

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -92,22 +92,18 @@ class ListTimetableCommand(_command.Command):
             else:
                 message += f" between {from_date_str} and {to_date_str}"
 
-            return {
-                "content": message,
-                "type": response_message.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-            }
+            return response_message.ChannelMessageResponseBody(message).as_dict()
 
         # Store the time period (default is 'from_date' if only 1 day requested) for the response message header
         time_period_str = from_date_str
         if days > 1:
             time_period_str += f" - {to_date_str}"
 
-        return {
-            "content": self._get_response_message(
+        return response_message.ChannelMessageResponseBody(
+            self._get_response_message(
                 filtered_timetable_sessions, f"{time_of_day.value} slots ({time_period_str})"
-            ),
-            "type": response_message.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-        }
+            )
+        ).as_dict()
 
     def _get_response_message(
         self, sessions: list[timetable.TimetableSession], header: str

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -3,7 +3,7 @@ import enum
 import typing
 
 from squash_bot.core import command as _command
-from squash_bot.core import command_registry, lambda_function
+from squash_bot.core import command_registry, response_message
 from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 
@@ -94,7 +94,7 @@ class ListTimetableCommand(_command.Command):
 
             return {
                 "content": message,
-                "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
+                "type": response_message.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
             }
 
         # Store the time period (default is 'from_date' if only 1 day requested) for the response message header
@@ -106,7 +106,7 @@ class ListTimetableCommand(_command.Command):
             "content": self._get_response_message(
                 filtered_timetable_sessions, f"{time_of_day.value} slots ({time_period_str})"
             ),
-            "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
+            "type": response_message.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
         }
 
     def _get_response_message(

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -50,7 +50,7 @@ class ListTimetableCommand(_command.Command):
         base_context: dict[str, typing.Any],
         guild: core_dataclasses.Guild,
         user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
+    ) -> response_message.ResponseBody:
         # From today's date
         from_date = datetime.datetime.now()
 
@@ -92,7 +92,7 @@ class ListTimetableCommand(_command.Command):
             else:
                 message += f" between {from_date_str} and {to_date_str}"
 
-            return response_message.ChannelMessageResponseBody(message).as_dict()
+            return response_message.ChannelMessageResponseBody(message)
 
         # Store the time period (default is 'from_date' if only 1 day requested) for the response message header
         time_period_str = from_date_str
@@ -103,7 +103,7 @@ class ListTimetableCommand(_command.Command):
             self._get_response_message(
                 filtered_timetable_sessions, f"{time_of_day.value} slots ({time_period_str})"
             )
-        ).as_dict()
+        )
 
     def _get_response_message(
         self, sessions: list[timetable.TimetableSession], header: str

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -77,7 +77,9 @@ class RecordMatchCommand(_command.Command):
         logger.info(f"Recording match: {match_result}")
         storage.store_match_result(match_result, guild)
 
-        return response_message.ChannelMessageResponseBody(utils.build_match_string(match_result))
+        return response_message.ChannelMessageResponseBody(
+            content=utils.build_match_string(match_result)
+        )
 
 
 class FilterOrderFormatMatchesMixin:
@@ -102,7 +104,7 @@ class FilterOrderFormatMatchesMixin:
         else:
             content = "No matches have been recorded."
 
-        return response_message.ChannelMessageResponseBody(content)
+        return response_message.ChannelMessageResponseBody(content=content)
 
 
 @command_registry.registry.register
@@ -136,7 +138,7 @@ class ShowMatchesCommand(_command.Command):
         else:
             content = "No matches have been recorded."
 
-        return response_message.ChannelMessageResponseBody(content)
+        return response_message.ChannelMessageResponseBody(content=content)
 
 
 @command_registry.registry.register

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -50,7 +50,7 @@ class RecordMatchCommand(_command.Command):
         base_context: dict[str, typing.Any],
         guild: core_dataclasses.Guild,
         user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
+    ) -> response_message.ResponseBody:
         loser, winner = sorted(
             [
                 (options["player-one"], options["player-one-score"]),
@@ -77,7 +77,7 @@ class RecordMatchCommand(_command.Command):
         logger.info(f"Recording match: {match_result}")
         storage.store_match_result(match_result, guild)
 
-        return response_message.ChannelMessageResponseBody(utils.build_match_string(match_result)).as_dict()
+        return response_message.ChannelMessageResponseBody(utils.build_match_string(match_result))
 
 
 class FilterOrderFormatMatchesMixin:
@@ -91,7 +91,7 @@ class FilterOrderFormatMatchesMixin:
         base_context: dict[str, typing.Any],
         guild: core_dataclasses.Guild,
         user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
+    ) -> response_message.ResponseBody:
         matches = queries.get_matches(guild)
 
         filtered_matches = self.filterer.filter(matches, **options)
@@ -102,7 +102,7 @@ class FilterOrderFormatMatchesMixin:
         else:
             content = "No matches have been recorded."
 
-        return response_message.ChannelMessageResponseBody(content).as_dict()
+        return response_message.ChannelMessageResponseBody(content)
 
 
 @command_registry.registry.register
@@ -125,7 +125,7 @@ class ShowMatchesCommand(_command.Command):
         base_context: dict[str, typing.Any],
         guild: core_dataclasses.Guild,
         user: core_dataclasses.User,
-    ) -> dict[str, typing.Any]:
+    ) -> response_message.ResponseBody:
         matches = queries.get_matches(guild)
 
         sort_by = options["sort-by"]
@@ -136,7 +136,7 @@ class ShowMatchesCommand(_command.Command):
         else:
             content = "No matches have been recorded."
 
-        return response_message.ChannelMessageResponseBody(content).as_dict()
+        return response_message.ChannelMessageResponseBody(content)
 
 
 @command_registry.registry.register

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -3,8 +3,8 @@ import logging
 import typing
 
 from squash_bot.core import command as _command
-from squash_bot.core import command_registry, lambda_function
 from squash_bot.core.data import constants as core_constants
+from squash_bot.core import command_registry, response_message
 from squash_bot.core.data import dataclasses as core_dataclasses
 from squash_bot.match_tracker import filterers, formatters, orderers, queries, utils, validate
 from squash_bot.match_tracker.data import dataclasses, storage
@@ -77,12 +77,7 @@ class RecordMatchCommand(_command.Command):
         logger.info(f"Recording match: {match_result}")
         storage.store_match_result(match_result, guild)
 
-        return {
-            "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-            "data": {
-                "content": utils.build_match_string(match_result),
-            },
-        }
+        return response_message.ChannelMessageResponseBody(utils.build_match_string(match_result)).as_dict()
 
 
 class FilterOrderFormatMatchesMixin:
@@ -107,12 +102,7 @@ class FilterOrderFormatMatchesMixin:
         else:
             content = "No matches have been recorded."
 
-        return {
-            "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-            "data": {
-                "content": content,
-            },
-        }
+        return response_message.ChannelMessageResponseBody(content).as_dict()
 
 
 @command_registry.registry.register
@@ -146,12 +136,7 @@ class ShowMatchesCommand(_command.Command):
         else:
             content = "No matches have been recorded."
 
-        return {
-            "type": lambda_function.InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
-            "data": {
-                "content": content,
-            },
-        }
+        return response_message.ChannelMessageResponseBody(content).as_dict()
 
 
 @command_registry.registry.register

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -3,8 +3,8 @@ import logging
 import typing
 
 from squash_bot.core import command as _command
-from squash_bot.core.data import constants as core_constants
 from squash_bot.core import command_registry, response_message
+from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 from squash_bot.match_tracker import filterers, formatters, orderers, queries, utils, validate
 from squash_bot.match_tracker.data import dataclasses, storage

--- a/tests/core/test_response_message.py
+++ b/tests/core/test_response_message.py
@@ -4,7 +4,9 @@ from squash_bot.core import response_message
 class TestResponseMessage:
     def test_channel_response_message_body(self):
         test_str = "This is a test"
-        channel_message_response_body = response_message.ChannelMessageResponseBody(test_str)
+        channel_message_response_body = response_message.ChannelMessageResponseBody(
+            content=test_str
+        )
         assert channel_message_response_body.as_dict() == {
             "type": 4,
             "data": {"content": test_str},
@@ -12,8 +14,8 @@ class TestResponseMessage:
 
     def test_ephemeral_channel_response_message_body(self):
         test_str = "This is another test"
-        ephemeral_channel_message_response_body = response_message.EphemeralChannelMessageResponseBody(
-            test_str
+        ephemeral_channel_message_response_body = (
+            response_message.EphemeralChannelMessageResponseBody(content=test_str)
         )
         assert ephemeral_channel_message_response_body.as_dict() == {
             "type": 4,

--- a/tests/core/test_response_message.py
+++ b/tests/core/test_response_message.py
@@ -1,0 +1,21 @@
+from squash_bot.core import response_message
+
+
+class TestResponseMessage:
+    def test_channel_response_message_body(self):
+        test_str = "This is a test"
+        channel_message_response_body = response_message.ChannelMessageResponseBody(test_str)
+        assert channel_message_response_body.as_dict() == {
+            "type": 4,
+            "data": {"content": test_str},
+        }
+
+    def test_ephemeral_channel_response_message_body(self):
+        test_str = "This is another test"
+        ephemeral_channel_message_response_body = response_message.EphemeralChannelMessageResponseBody(
+            test_str
+        )
+        assert ephemeral_channel_message_response_body.as_dict() == {
+            "type": 4,
+            "data": {"content": test_str, "flags": 64},
+        }

--- a/tests/list_timetable/test_command.py
+++ b/tests/list_timetable/test_command.py
@@ -71,7 +71,7 @@ class TestCommand:
             "type": 4,
             "data": {
                 "content": f"Any slots (25-03):\n* [25-03 21:00: 2 slots available]({api_url}/enterprise/bookingscentre/membertimetable#Details?&ResourceScheduleId=1900373)",
-            }
+            },
         }
 
     def test_no_available_sessions(self):
@@ -131,5 +131,5 @@ class TestCommand:
             "type": 4,
             "data": {
                 "content": "No available sessions on 25-03",
-            }
+            },
         }

--- a/tests/list_timetable/test_command.py
+++ b/tests/list_timetable/test_command.py
@@ -65,11 +65,13 @@ class TestCommand:
                             }
                         },
                     }
-                )
+                ).as_dict()
 
         assert response == {
-            "content": f"Any slots (25-03):\n* [25-03 21:00: 2 slots available]({api_url}/enterprise/bookingscentre/membertimetable#Details?&ResourceScheduleId=1900373)",
             "type": 4,
+            "data": {
+                "content": f"Any slots (25-03):\n* [25-03 21:00: 2 slots available]({api_url}/enterprise/bookingscentre/membertimetable#Details?&ResourceScheduleId=1900373)",
+            }
         }
 
     def test_no_available_sessions(self):
@@ -123,9 +125,11 @@ class TestCommand:
                             }
                         },
                     }
-                )
+                ).as_dict()
 
         assert response == {
-            "content": "No available sessions on 25-03",
             "type": 4,
+            "data": {
+                "content": "No available sessions on 25-03",
+            }
         }

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -44,7 +44,8 @@ class TestRecordMatchCommand:
                     }
                 },
             }
-        )
+        ).as_dict()
+
         assert "global1" in response["data"]["content"]
         assert "global2" in response["data"]["content"]
 
@@ -83,7 +84,8 @@ class TestRecordMatchCommand:
                     }
                 },
             }
-        )
+        ).as_dict()
+
         assert "user1" in response["data"]["content"]
         assert "user2" in response["data"]["content"]
 
@@ -123,7 +125,7 @@ class TestRecordMatchCommand:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         all_match_results = storage.get_all_match_results(
             guild=core_dataclasses.Guild(guild_id="1")
@@ -165,7 +167,7 @@ class TestShowMatches:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         assert "No matches have been recorded" in response["data"]["content"]
 
@@ -194,7 +196,7 @@ class TestShowMatches:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         content = response["data"]["content"]
         assert (
@@ -221,7 +223,7 @@ class TestLeagueTable:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         assert "No matches have been recorded" in response["data"]["content"]
 
@@ -254,7 +256,7 @@ class TestLeagueTable:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         content = response["data"]["content"]
         table_data = _extract_data_from_table_string(content)
@@ -298,7 +300,7 @@ class TestLeagueTable:
                         }
                     },
                 }
-            )
+            ).as_dict()
 
         content = response["data"]["content"]
         table_data = _extract_data_from_table_string(content)


### PR DESCRIPTION
Side note: This also fixes a bug with the `list-timetable` command which was structured as `{ 'content': content }` when it should have been `{ 'data': { 'content': content } }`