### PR TITLE
Add win percentage to league table command output

### DIFF
--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -50,11 +50,13 @@ class LeagueTable(Formatter):
         for player, results in player_results.items():
             wins = results.get("wins", 0)
             losses = results.get("losses", 0)
+            total_games = wins + losses
+            win_percentage = int((wins / total_games) * 100)
 
-            player_rows.append([player.name, wins, losses])
+            player_rows.append([player.name, wins, losses, win_percentage])
 
         inner_message = tabulate.tabulate(
-            player_rows, ["Player", "Wins", "Losses"], tablefmt="rounded_grid"
+            player_rows, ["Player", "Wins", "Losses", "Win %"], tablefmt="rounded_grid"
         )
 
         return f"```{inner_message}```"

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -55,6 +55,9 @@ class LeagueTable(Formatter):
 
             player_rows.append([player.name, wins, losses, win_percentage])
 
+        # Sort by descending win percentage
+        player_rows = sorted(player_rows, key=lambda row: row[3], reverse=True)
+
         inner_message = tabulate.tabulate(
             player_rows, ["Player", "Wins", "Losses", "Win %"], tablefmt="rounded_grid"
         )

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -257,8 +257,9 @@ class TestLeagueTable:
             )
 
         content = response["data"]["content"]
-        assert "global-user1 │      1 │        1" in content
-        assert "global-user2 │      1 │        1" in content
+        table_data = _extract_data_from_table_string(content)
+        assert ["global-user2", "1", "1", "50%"] in table_data
+        assert ["global-user1", "1", "1", "50%"] in table_data
 
     def test_league_table_with_datetime_filter(self):
         user_one = core_dataclasses.User(id="1", username="user1", global_name="global-user1")
@@ -300,5 +301,16 @@ class TestLeagueTable:
             )
 
         content = response["data"]["content"]
-        assert "global-user2 │      1 │        0" in content
-        assert "global-user1 │      0 │        1" in content
+        table_data = _extract_data_from_table_string(content)
+        assert ["global-user2", "1", "0", "100%"] in table_data
+        assert ["global-user1", "0", "1", "0%"] in table_data
+
+
+def _extract_data_from_table_string(
+    table_string: str, column_separator: str = "│"
+) -> list[list[str]]:
+    data = []
+    for line in table_string.replace("```", "").split("\n"):
+        parts = line.split(column_separator)
+        data.append([part.strip() for part in parts if part.strip()])
+    return data

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -258,7 +258,7 @@ class TestLeagueTable:
 
         content = response["data"]["content"]
         assert "global-user1 │      1 │        1" in content
-        assert "global-user2 │      1 │  " in content
+        assert "global-user2 │      1 │        1" in content
 
     def test_league_table_with_datetime_filter(self):
         user_one = core_dataclasses.User(id="1", username="user1", global_name="global-user1")


### PR DESCRIPTION
Adds a win percentage column to replace the old point difference column and sorts the output by that win percentage.