### PR TITLE
Added choices property to options

### DIFF
--- a/slash_command_register/register.py
+++ b/slash_command_register/register.py
@@ -37,6 +37,7 @@ def _build_dict_for_option(
         "description": command_option.description,
         "type": command_option.type.value,
         "required": command_option.required,
+        "choices": [choice.as_dict() for choice in command_option.choices if choice.type is command_option.type]
     }
 
 

--- a/slash_command_register/register.py
+++ b/slash_command_register/register.py
@@ -37,7 +37,11 @@ def _build_dict_for_option(
         "description": command_option.description,
         "type": command_option.type.value,
         "required": command_option.required,
-        "choices": [choice.as_dict() for choice in command_option.choices if choice.type is command_option.type]
+        "choices": [
+            choice.as_dict()
+            for choice in command_option.choices
+            if choice.type is command_option.type
+        ],
     }
 
 

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -35,6 +35,7 @@ class CommandOptionChoice:
     A predetermined choice for a command option.
     Note: type MUST match the CommandOption.type otherwise the choices will fail to be included
     """
+
     name: str
     value: str | int | float
     type: CommandOptionType
@@ -50,7 +51,7 @@ class CommandOption:
     type: CommandOptionType
     required: bool
     default: typing.Any | None = None
-    choices: tuple[CommandOptionChoice]
+    choices: tuple[CommandOptionChoice] | None = None
 
     @property
     def is_user(self) -> bool:

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -51,7 +51,7 @@ class CommandOption:
     type: CommandOptionType
     required: bool
     default: typing.Any | None = None
-    choices: tuple[CommandOptionChoice] | None = None
+    choices: tuple[CommandOptionChoice, ...] | None = None
 
     @property
     def is_user(self) -> bool:

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -30,12 +30,27 @@ class CommandOptionType(enum.Enum):
 
 
 @attrs.frozen
+class CommandOptionChoice:
+    """
+    A predetermined choice for a command option.
+    Note: type MUST match the CommandOption.type otherwise the choices will fail
+    """
+    name: str
+    value: str | int | float
+    type: CommandOptionType
+
+    def as_dict(self) -> dict[str, str | int | float]:
+        return {"name": self.name, "value": self.value}
+
+
+@attrs.frozen
 class CommandOption:
     name: str
     description: str
     type: CommandOptionType
     required: bool
     default: typing.Any | None = None
+    choices: tuple[CommandOptionChoice]
 
     @property
     def is_user(self) -> bool:

--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -33,7 +33,7 @@ class CommandOptionType(enum.Enum):
 class CommandOptionChoice:
     """
     A predetermined choice for a command option.
-    Note: type MUST match the CommandOption.type otherwise the choices will fail
+    Note: type MUST match the CommandOption.type otherwise the choices will fail to be included
     """
     name: str
     value: str | int | float

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -35,6 +35,10 @@ class ListTimetableCommand(_command.Command):
             type=_command.CommandOptionType.STRING,
             default=timetable.TimeOfDayType.ANY.value,
             required=False,
+            choices=(
+                _command.CommandOptionChoice(time_of_day.value, time_of_day.value)
+                for time_of_day in timetable.TimeOfDayType
+            ),
         ),
     )
     _timetable = timetable.CelticLeisureTimetable()


### PR DESCRIPTION
As long as your choices are either a `str`, `int`, or `float`, and the choice type matches the `CommandOption` type, the choices will be displayed for a command if present.
Default choices to `None` to ensure consistent behaviour from before.
Added a choice for `time-of-day` in `list-timetable` command.

See: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure for choices deets (also, do a Ctrl+F for 'choices' to see some examples of what the choices should look like in an option)

Note: I haven't been tidy with the commit order, but there's not a lot of changes to go through anyway