### PR TITLE
Move `CommandOptionType` to constants file

### DIFF
--- a/squash_bot/core/command.py
+++ b/squash_bot/core/command.py
@@ -1,8 +1,8 @@
-import enum
 import typing
 
 import attrs
 
+from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 
 
@@ -18,28 +18,17 @@ class CommandVerificationError(CommandError):
     """
 
 
-class CommandOptionType(enum.Enum):
-    SUB_COMMAND = 1
-    SUB_COMMAND_GROUP = 2
-    STRING = 3
-    INTEGER = 4
-    BOOLEAN = 5
-    USER = 6
-    CHANNEL = 7
-    ROLE = 8
-
-
 @attrs.frozen
 class CommandOption:
     name: str
     description: str
-    type: CommandOptionType
+    type: core_constants.CommandOptionType
     required: bool
     default: typing.Any | None = None
 
     @property
     def is_user(self) -> bool:
-        return self.type == CommandOptionType.USER
+        return self.type == core_constants.CommandOptionType.USER
 
 
 class Command:

--- a/squash_bot/core/data/constants.py
+++ b/squash_bot/core/data/constants.py
@@ -1,0 +1,12 @@
+import enum
+
+
+class CommandOptionType(enum.Enum):
+    SUB_COMMAND = 1
+    SUB_COMMAND_GROUP = 2
+    STRING = 3
+    INTEGER = 4
+    BOOLEAN = 5
+    USER = 6
+    CHANNEL = 7
+    ROLE = 8

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -5,6 +5,7 @@ import typing
 from squash_bot.core import command as _command
 from squash_bot.core import command_registry, lambda_function
 from squash_bot.core.command import CommandVerificationError
+from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 
 from . import timetable
@@ -25,13 +26,13 @@ class ListTimetableCommand(_command.Command):
         _command.CommandOption(
             name=ListTimetableOptionType.DAYS.value,
             description="The amount of days to check for squash sessions",
-            type=_command.CommandOptionType.INTEGER,
+            type=core_constants.CommandOptionType.INTEGER,
             required=True,
         ),
         _command.CommandOption(
             name=ListTimetableOptionType.TIME_OF_DAY.value,
             description="The specified time of day to filter specific squash sessions. Default = Any",
-            type=_command.CommandOptionType.STRING,
+            type=core_constants.CommandOptionType.STRING,
             default=timetable.TimeOfDayType.ANY.value,
             required=False,
         ),

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -2,13 +2,12 @@ import datetime
 import enum
 import typing
 
-from . import timetable
-
 from squash_bot.core import command as _command
 from squash_bot.core import command_registry, lambda_function
 from squash_bot.core.command import CommandVerificationError
 from squash_bot.core.data import dataclasses as core_dataclasses
 
+from . import timetable
 
 DISCORD_COMMAND_DATETIME_FORMAT = "%d-%m"
 

--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -4,6 +4,7 @@ import typing
 
 from squash_bot.core import command as _command
 from squash_bot.core import command_registry, lambda_function
+from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 from squash_bot.match_tracker import filterers, formatters, orderers, queries, utils, validate
 from squash_bot.match_tracker.data import dataclasses, storage
@@ -20,25 +21,25 @@ class RecordMatchCommand(_command.Command):
         _command.CommandOption(
             name="player-one",
             description="Player one",
-            type=_command.CommandOptionType.USER,
+            type=core_constants.CommandOptionType.USER,
             required=True,
         ),
         _command.CommandOption(
             name="player-one-score",
             description="Player one's score",
-            type=_command.CommandOptionType.INTEGER,
+            type=core_constants.CommandOptionType.INTEGER,
             required=True,
         ),
         _command.CommandOption(
             name="player-two",
             description="Player two",
-            type=_command.CommandOptionType.USER,
+            type=core_constants.CommandOptionType.USER,
             required=True,
         ),
         _command.CommandOption(
             name="player-two-score",
             description="Player two's score",
-            type=_command.CommandOptionType.INTEGER,
+            type=core_constants.CommandOptionType.INTEGER,
             required=True,
         ),
     )
@@ -122,7 +123,7 @@ class ShowMatchesCommand(_command.Command):
         _command.CommandOption(
             name="sort-by",
             description="The field to sort the matches by. Defaults to `played_at`.",
-            type=_command.CommandOptionType.STRING,
+            type=core_constants.CommandOptionType.STRING,
             required=False,
             default="played_at",
         ),
@@ -161,7 +162,7 @@ class LeagueTableCommand(FilterOrderFormatMatchesMixin, _command.Command):
         _command.CommandOption(
             name="include-matches-from",
             description="Only include matches played on or after this date. Defaults to all time.",
-            type=_command.CommandOptionType.STRING,
+            type=core_constants.CommandOptionType.STRING,
             required=False,
         ),
     )

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -1,6 +1,7 @@
 import pytest
 
 from squash_bot.core import command as _command
+from squash_bot.core.data import constants as core_constants
 from squash_bot.core.data import dataclasses as core_dataclasses
 
 
@@ -13,7 +14,7 @@ class TestParseOptions:
                 _command.CommandOption(
                     name="required-option",
                     description="A required option",
-                    type=_command.CommandOptionType.STRING,
+                    type=core_constants.CommandOptionType.STRING,
                     required=True,
                 ),
             )
@@ -33,7 +34,7 @@ class TestParseOptions:
                 _command.CommandOption(
                     name="required-option",
                     description="A required option",
-                    type=_command.CommandOptionType.STRING,
+                    type=core_constants.CommandOptionType.STRING,
                     required=True,
                 ),
             )
@@ -65,7 +66,7 @@ class TestParseOptions:
                 _command.CommandOption(
                     name="user",
                     description="User",
-                    type=_command.CommandOptionType.USER,
+                    type=core_constants.CommandOptionType.USER,
                     required=True,
                 ),
             )
@@ -108,7 +109,7 @@ class TestParseOptions:
                 _command.CommandOption(
                     name="required-option",
                     description="A required option",
-                    type=_command.CommandOptionType.STRING,
+                    type=core_constants.CommandOptionType.STRING,
                     required=False,
                     default="default-value",
                 ),
@@ -127,7 +128,7 @@ class TestParseOptions:
                 _command.CommandOption(
                     name="required-option",
                     description="A required option",
-                    type=_command.CommandOptionType.STRING,
+                    type=core_constants.CommandOptionType.STRING,
                     required=False,
                     default="default-value",
                 ),


### PR DESCRIPTION
Makes it slightly easier to import on it's own rather than having to import the whole `command.py` file.