### PR TITLE
Fix option choices in registry & list_timetable command

### DIFF
--- a/slash_command_register/register.py
+++ b/slash_command_register/register.py
@@ -32,17 +32,20 @@ def _build_dict_for_command(command: _command.Command) -> dict[str, typing.Any]:
 def _build_dict_for_option(
     command_option: _command.CommandOption,
 ) -> dict[str, typing.Any]:
-    return {
+    option_dict = {
         "name": command_option.name,
         "description": command_option.description,
         "type": command_option.type.value,
         "required": command_option.required,
-        "choices": [
-            choice.as_dict()
-            for choice in command_option.choices
-            if choice.type is command_option.type
-        ],
     }
+    if not command_option.choices:
+        return option_dict
+
+    if choices := [
+        choice.as_dict() for choice in command_option.choices if choice.type is command_option.type
+    ]:
+        option_dict["choices"] = choices
+    return option_dict
 
 
 def _outputer_from_settings() -> outputer.Outputer:

--- a/squash_bot/list_timetable/commands.py
+++ b/squash_bot/list_timetable/commands.py
@@ -36,7 +36,9 @@ class ListTimetableCommand(_command.Command):
             default=timetable.TimeOfDayType.ANY.value,
             required=False,
             choices=(
-                _command.CommandOptionChoice(time_of_day.value, time_of_day.value)
+                _command.CommandOptionChoice(
+                    time_of_day.value, time_of_day.value, _command.CommandOptionType.STRING
+                )
                 for time_of_day in timetable.TimeOfDayType
             ),
         ),


### PR DESCRIPTION
When choices is `None`, we don't want to include a "choices" field. Also, the `type` was missing in the Choice creation in list_timetable.command.py command