### PR TITLE
Improvements to the `show-matches` command

### DIFF
--- a/squash_bot/match_tracker/commands.py
+++ b/squash_bot/match_tracker/commands.py
@@ -108,7 +108,7 @@ class FilterOrderFormatMatchesMixin:
 
 
 @command_registry.registry.register
-class ShowMatchesCommand(_command.Command):
+class ShowMatchesCommand(FilterOrderFormatMatchesMixin, _command.Command):
     name = "show-matches"
     description = "Show saved matches."
     options = (
@@ -121,24 +121,8 @@ class ShowMatchesCommand(_command.Command):
         ),
     )
 
-    def _handle(
-        self,
-        options: dict[str, typing.Any],
-        base_context: dict[str, typing.Any],
-        guild: core_dataclasses.Guild,
-        user: core_dataclasses.User,
-    ) -> response_message.ResponseBody:
-        matches = queries.get_matches(guild)
-
-        sort_by = options["sort-by"]
-        matches = matches.sort_by(sort_by)
-
-        if matches:
-            content = formatters.PlayedAtFormatter.format_matches(matches)
-        else:
-            content = "No matches have been recorded."
-
-        return response_message.ChannelMessageResponseBody(content=content)
+    orderer = orderers.OptionalByMatchesField
+    formatter = formatters.PlayedAtFormatter
 
 
 @command_registry.registry.register

--- a/squash_bot/match_tracker/data/dataclasses.py
+++ b/squash_bot/match_tracker/data/dataclasses.py
@@ -29,6 +29,18 @@ class MatchResult:
     def played_on(self) -> datetime.date:
         return self.played_at.date()
 
+    @property
+    def server_score(self) -> int:
+        return self.winner_score if self.served == self.winner else self.loser_score
+
+    @property
+    def receiver(self) -> core_dataclasses.User:
+        return self.loser if self.served == self.winner else self.winner
+
+    @property
+    def receiver_score(self) -> int:
+        return self.winner_score if self.receiver == self.winner else self.loser_score
+
     def __str__(self):
         return f"{self.winner.username} beat {self.loser.username} {self.winner_score}-{self.loser_score} on {self.played_on.isoformat()}"
 

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -22,6 +22,22 @@ class BasicFormatter(Formatter):
         return f"```{inner_message}```"
 
 
+@attrs.frozen
+class MatchRow:
+    first_player: core_dataclasses.User
+    first_player_score: int
+    second_player_score: int
+    second_player: core_dataclasses.User
+
+    def as_display_row(self) -> list[str]:
+        score_string = f"{self.first_player_score} - {self.second_player_score}"
+        return [
+            self.first_player.name,
+            score_string,
+            self.second_player.name,
+        ]
+
+
 class PlayedAtFormatter(Formatter):
     @classmethod
     def format_matches(cls, matches: dataclasses.Matches, **kwargs) -> str:
@@ -30,10 +46,19 @@ class PlayedAtFormatter(Formatter):
         inner_message = ""
         for played_at, match_results in groups:
             pretty_date = played_at.strftime("%A, %-d %B %Y")
-            inner_message += f"\n\n{pretty_date}:"
-            for match in match_results:
-                match_string = _match_string(match)
-                inner_message += f"\n\t{match_string}"
+            inner_message += f"\n\n{pretty_date}:\n"
+            inner_message += tabulate.tabulate(
+                [
+                    MatchRow(
+                        first_player=match.winner,
+                        first_player_score=match.winner_score,
+                        second_player_score=match.loser_score,
+                        second_player=match.loser,
+                    ).as_display_row()
+                    for match in match_results
+                ],
+                tablefmt="plain",
+            )
 
         return f"```{inner_message}```"
 

--- a/squash_bot/match_tracker/formatters.py
+++ b/squash_bot/match_tracker/formatters.py
@@ -88,12 +88,4 @@ class LeagueTable(Formatter):
 
 
 def _match_string(match: dataclasses.MatchResult) -> str:
-    served_marker = "*"
-    if match.served == match.winner:
-        winner_name = f"{match.winner.name}{served_marker}"
-        loser_name = f"{match.loser.name}"
-    else:
-        winner_name = f"{match.winner.name}"
-        loser_name = f"{match.loser.name}{served_marker}"
-
-    return f"{winner_name}\t{match.winner_score} - {match.loser_score}\t{loser_name}"
+    return f"{match.served.name}\t{match.server_score} - {match.receiver_score}\t{match.receiver.name}"

--- a/squash_bot/match_tracker/orderers.py
+++ b/squash_bot/match_tracker/orderers.py
@@ -13,3 +13,16 @@ class NoopOrderer(Orderer):
     @classmethod
     def order(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
         return matches
+
+
+class OptionalByMatchesField(Orderer):
+    @classmethod
+    def order(cls, matches: dataclasses.Matches, **kwargs) -> dataclasses.Matches:
+        field = kwargs.get("field")
+        if not field:
+            return matches
+
+        try:
+            return matches.sort_by(field)
+        except dataclasses.FieldDoesNotExist:
+            return matches

--- a/tests/factories/match_tracker.py
+++ b/tests/factories/match_tracker.py
@@ -9,11 +9,15 @@ from tests.factories import core as core_factories
 
 
 class MatchResultFactory(factory.Factory):
-    winner = factory.SubFactory(core_factories.UserFactory)
+    winner = factory.SubFactory(
+        core_factories.UserFactory, id=1, username="Paul", global_name="Paul!"
+    )
     winner_score = 11
     loser_score = 3
-    loser = factory.SubFactory(core_factories.UserFactory)
-    served = factory.SubFactory(core_factories.UserFactory)
+    loser = factory.SubFactory(
+        core_factories.UserFactory, id=2, username="John", global_name="John!"
+    )
+    served = factory.SelfAttribute("loser")
     played_at = factory.LazyFunction(datetime.datetime.now)
     logged_at = factory.LazyFunction(datetime.datetime.now)
     logged_by = factory.SubFactory(core_factories.UserFactory)

--- a/tests/match_tracker/data/test_dataclasses.py
+++ b/tests/match_tracker/data/test_dataclasses.py
@@ -82,6 +82,18 @@ class TestMatchResult:
             result_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),
         )
 
+    def test_receiver(self):
+        match_result = match_tracker_factories.MatchResultFactory()
+        assert match_result.receiver == match_result.winner
+
+    def test_receiver_score(self):
+        match_result = match_tracker_factories.MatchResultFactory()
+        assert match_result.receiver_score == match_result.winner_score
+
+    def test_server_score(self):
+        match_result = match_tracker_factories.MatchResultFactory()
+        assert match_result.server_score == match_result.loser_score
+
 
 class TestMatches:
     def test_sort_by_datetime(self):

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -201,7 +201,7 @@ class TestShowMatches:
         content = response["data"]["content"]
         assert (
             content
-            == "```\n\nFriday, 1 January 2021:\n\tJohn!\t3 - 11\tPaul!\n\nSaturday, 2 January 2021:\n\tJohn!\t3 - 11\tPaul!```"
+            == "```\n\nFriday, 1 January 2021:\nPaul!  11 - 3  John!\n\nSaturday, 2 January 2021:\nPaul!  11 - 3  John!```"
         )
 
 

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -201,7 +201,7 @@ class TestShowMatches:
         content = response["data"]["content"]
         assert (
             content
-            == "```\n\nFriday, 1 January 2021:\n\tPaul*\t11 - 3\tPaul\n\nSaturday, 2 January 2021:\n\tPaul*\t11 - 3\tPaul```"
+            == "```\n\nFriday, 1 January 2021:\n\tPaul!\t11 - 3\tJohn!*\n\nSaturday, 2 January 2021:\n\tPaul!\t11 - 3\tJohn!*```"
         )
 
 

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -201,7 +201,7 @@ class TestShowMatches:
         content = response["data"]["content"]
         assert (
             content
-            == "```\n\nFriday, 1 January 2021:\n\tPaul!\t11 - 3\tJohn!*\n\nSaturday, 2 January 2021:\n\tPaul!\t11 - 3\tJohn!*```"
+            == "```\n\nFriday, 1 January 2021:\n\tJohn!\t3 - 11\tPaul!\n\nSaturday, 2 January 2021:\n\tJohn!\t3 - 11\tPaul!```"
         )
 
 


### PR DESCRIPTION
This PR:
- Changes `ShowMatchesCommand` to use the new mixin
- Formats the matches with the sever first, instead of the winner first
- Uses tabulate to help with the table formatting