### PR TITLE
Make `served` random in `MatchResultFactory`

### DIFF
--- a/tests/factories/match_tracker.py
+++ b/tests/factories/match_tracker.py
@@ -17,7 +17,7 @@ class MatchResultFactory(factory.Factory):
     loser = factory.SubFactory(
         core_factories.UserFactory, id=2, username="John", global_name="John!"
     )
-    served = factory.SelfAttribute("loser")
+    served = factory.LazyAttribute(lambda r: random.choice([r.winner, r.loser]))
     played_at = factory.LazyFunction(datetime.datetime.now)
     logged_at = factory.LazyFunction(datetime.datetime.now)
     logged_by = factory.SubFactory(core_factories.UserFactory)

--- a/tests/match_tracker/data/test_dataclasses.py
+++ b/tests/match_tracker/data/test_dataclasses.py
@@ -83,15 +83,15 @@ class TestMatchResult:
         )
 
     def test_receiver(self):
-        match_result = match_tracker_factories.MatchResultFactory()
+        match_result = match_tracker_factories.MatchResultFactory(served="..loser")
         assert match_result.receiver == match_result.winner
 
     def test_receiver_score(self):
-        match_result = match_tracker_factories.MatchResultFactory()
+        match_result = match_tracker_factories.MatchResultFactory(served="..loser")
         assert match_result.receiver_score == match_result.winner_score
 
     def test_server_score(self):
-        match_result = match_tracker_factories.MatchResultFactory()
+        match_result = match_tracker_factories.MatchResultFactory(served="..loser")
         assert match_result.server_score == match_result.loser_score
 
 

--- a/tests/match_tracker/test_commands.py
+++ b/tests/match_tracker/test_commands.py
@@ -173,10 +173,14 @@ class TestShowMatches:
 
     def test_show_matches(self):
         match_one_played_at = datetime.datetime(2021, 1, 1, 12, 0)
-        match_one = match_tracker_factories.MatchResultFactory(played_at=match_one_played_at)
+        match_one = match_tracker_factories.MatchResultFactory(
+            played_at=match_one_played_at, served="..loser"
+        )
 
         match_two_played_at = datetime.datetime(2021, 1, 2, 12, 0)
-        match_two = match_tracker_factories.MatchResultFactory(played_at=match_two_played_at)
+        match_two = match_tracker_factories.MatchResultFactory(
+            played_at=match_two_played_at, served="..loser"
+        )
 
         matches = dataclasses.Matches(match_results=[match_one, match_two])
 


### PR DESCRIPTION
Prior to this change, the `loser` was always the player that served, it will be better to flush out bad code if the server is random.