### PR TITLE
Improve `UserFactory`

### DIFF
--- a/tests/factories/core.py
+++ b/tests/factories/core.py
@@ -4,9 +4,9 @@ from squash_bot.core.data import dataclasses
 
 
 class UserFactory(factory.Factory):
-    id = 1
+    id = factory.Sequence(lambda n: n)
     username = "paul"
-    global_name = "Paul"
+    global_name = factory.LazyAttribute(lambda user: user.username.title())
 
     class Meta:
         model = dataclasses.User


### PR DESCRIPTION
Prior to this change, the factory would always create the a user with the same `id`.

This change makes the id change so successive calls to `UserFactory` produces distinct `User` instances.